### PR TITLE
fix transform returning undefined w/ cursor

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,10 +36,10 @@ function attachVirtuals(schema) {
       if (Array.isArray(res)) {
         var len = res.length;
         for (var i = 0; i < len; ++i) {
-          attachVirtualsToDoc(res[i], toApply, numVirtuals);
+          return attachVirtualsToDoc(res[i], toApply, numVirtuals);
         }
       } else {
-        attachVirtualsToDoc(res, toApply, numVirtuals);
+        return attachVirtualsToDoc(res, toApply, numVirtuals);
       }
     } else {
       return res
@@ -57,5 +57,6 @@ function attachVirtuals(schema) {
       }
       cur[sp[sp.length - 1]] = schema.virtuals[virtual].applyGetters(void 0, doc);
     }
+    return cur;
   }
 }


### PR DESCRIPTION
Almost the same as #11 but here it is for when used w/ `.lean({ virtuals: true })`.
In the case this plugin is hooked on transforms, which are applied in a `.reduce` ([here](https://github.com/Automattic/mongoose/blob/master/lib/cursor/QueryCursor.js#L253)), but `undefined` is returned since the document is mutated but not returned.