### PR TITLE
Fix for where 'ref' is in options

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function attachVirtuals(schema) {
     var virtuals = [];
     var keys = Object.keys(schema.virtuals);
     for (var i = 0; i < keys.length; ++i) {
-      if (!schema.virtuals[keys[i]].ref) {
+      if (!schema.virtuals[keys[i]].ref && (!schema.virtuals[keys[i]].options || !schema.virtuals[keys[i]].options.ref)) {
         virtuals.push(keys[i]);
       }
     }


### PR DESCRIPTION
Virtuals for use with populate() can have the 'ref' property in the options, which up until now has been ignored.
For example, a virtual field declared like below would not be caught by the 'ref' check in the current version of mongoose-lean-virtuals, and if the 'books' field was populated before running `.lean({ virtuals: true})` then the 'books' field would be overwritten with `null`.
This PR fixes that.

```
const BookSchema = new Schema({
  user: { type: Schema.Types.ObjectId, ref: 'User' },
  title: String,
  author: String
}, {
  timestamps: true
});
var BookModel = model<Book>('Book', BookSchema);

const UserSchema = new Schema({
  company: String,
  name: String
}, {
  timestamps: true,
  toObject: { virtuals: true },
  toJSON: { virtuals: true }
});

UserSchema.virtual('books', {
  ref: 'Book',
  localField: '_id',
  foreignField: 'user'
});
```