### PR TITLE
Avoid undefined doc from being virtualized

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,6 +76,7 @@ function attachVirtuals(schema, res) {
 
 function attachVirtualsToDoc(schema, doc, virtuals) {
   const numVirtuals = virtuals.length;
+  if (doc == null) return;
   if (Array.isArray(doc)) {
     for (let i = 0; i < doc.length; ++i) {
       attachVirtualsToDoc(schema, doc[i], virtuals);


### PR DESCRIPTION
Following [this commit ](https://github.com/vkarpov15/mongoose-lean-virtuals/commit/b734425837cec9a3f7a6b1ab2fee8b1cbc8d95c5) nested schemas are virtualized. But I've faced some issue due to this since some of my documents are not strictly following the Mongoose schema I've defined.

If we define the following Mongoose schema : 
``` javascript
{
  someKey: String,
  someArray: [
    {
      someOtherKey: String,
    }
  ]
}
```
... but we have one document like that : 
``` javascript
{
  "someKey": "someValue",
}
```
... a `find({}).lean({virtuals: true})` will fail with `Cannot read property '_id' of undefined`. This PR fixes that undesired behavior.