### PR TITLE
Correctly pass existing field value to applyGetters

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,6 +113,6 @@ function attachVirtualsToDoc(schema, doc, virtuals) {
       cur[sp[j]] = sp[j] in cur ? cur[sp[j]] : {};
       cur = cur[sp[j]];
     }
-    cur[sp[sp.length - 1]] = schema.virtuals[virtual].applyGetters(void 0, doc);
+    cur[sp[sp.length - 1]] = schema.virtuals[virtual].applyGetters(cur[sp[sp.length - 1]], doc);
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "mongoose": "5.x"
   },
   "peerDependencies": {
-    "mongoose": ">=4.11.0 || 5.x"
+    "mongoose": ">=5.9.9"
   },
   "author": "Valeri Karpov <val@karpov.io>",
   "license": "Apache 2.0",


### PR DESCRIPTION
Fixes #25

- Added test for this case (a getter function on a virtual in a lean query)
- Updated the mongoose peer dependency to the first version that has the fix to Automattic/mongoose#8775