### PR TITLE
Allow virtual nested objects to work

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,8 +124,10 @@ function applyVirtualsToChildren(doc, schema, res, virtuals, parent) {
       }
     }
 
-    attachVirtuals.call(doc, _schema, _doc, virtualsForChild, res);
-    attachedVirtuals = true;
+    if (virtualsForChild.length > 0) {
+      attachVirtuals.call(doc, _schema, _doc, virtualsForChild, res);
+      attachedVirtuals = true;
+    }
   }
 
   if (virtuals && virtuals.length && !attachedVirtuals) {

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ function attachVirtuals(schema, res, virtuals, parent) {
     }
   }
 
-  applyVirtualsToChildren(this, schema, res, virtualsForChildren);
+  applyVirtualsToChildren(this, schema, res, virtualsForChildren, parent);
   return applyVirtualsToResult(schema, res, toApply, parent);
 }
 
@@ -98,8 +98,9 @@ function applyVirtualsToResult(schema, res, toApply, parent) {
   }
 }
 
-function applyVirtualsToChildren(doc, schema, res, virtuals) {
+function applyVirtualsToChildren(doc, schema, res, virtuals, parent) {
   const len = schema.childSchemas.length;
+  let attachedVirtuals = false;
   for (let i = 0; i < len; ++i) {
     const _path = schema.childSchemas[i].model.path;
     const _schema = schema.childSchemas[i].schema;
@@ -124,6 +125,13 @@ function applyVirtualsToChildren(doc, schema, res, virtuals) {
     }
 
     attachVirtuals.call(doc, _schema, _doc, virtualsForChild, res);
+    attachedVirtuals = true;
+  }
+
+  if (virtuals && virtuals.length && !attachedVirtuals) {
+    attachVirtualsToDoc(schema, res, virtuals.map(function(virtual) {
+      return virtual.join('.');
+    }), parent);
   }
 }
 

--- a/test/examples.test.js
+++ b/test/examples.test.js
@@ -170,4 +170,29 @@ describe('examples', function() {
         assert.equal(result.childs[0].uppercaseOther, 'VAL');
       });
   });
+
+  it('nested virtuals that are objects return the value (gh-43)', function() {
+    const schema = new mongoose.Schema({
+      nested: {
+        test: {
+          a: String
+        }
+      }
+    }, { id: false });
+
+    schema.virtual('nested.test2').get(function() {
+      return this.nested.test;
+    });
+
+    schema.plugin(mongooseLeanVirtuals);
+
+    const Model = mongoose.model('gh43c', schema);
+
+    return Model.create({ nested: { test: { a: 'Val' } } }).
+      then(() => Model.findOne().lean({ virtuals: ['nested.test2'] })).
+      then(result => {
+        assert.equal(result.nested.test.a, 'Val');
+        assert.equal(result.nested.test2.a, 'Val');
+      });
+  });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -45,7 +45,10 @@ before(function() {
     baseSchema = new mongoose.Schema({
       name: String,
       nested: {
-        test: String
+        test: String,
+        objectTest: {
+          test: String
+        }
       }
     });
     baseSchema.virtual('lowerCaseName').get(function() {
@@ -53,6 +56,9 @@ before(function() {
     });
     baseSchema.virtual('nested.upperCaseTest').get(function() {
       return this.nested.test.toUpperCase();
+    });
+    baseSchema.virtual('nested.virtualObjectTest').get(function() {
+      return this.nested.objectTest;
     });
     baseSchema.plugin(mongooseLeanVirtuals);
 
@@ -62,6 +68,9 @@ before(function() {
       name: 'Val',
       nested: {
         test: 'Foo',
+        objectTest: {
+          test: 'Bar'
+        }
       }
     };
     const baseDoc = yield baseModel.create(baseObj);
@@ -156,6 +165,25 @@ describe('Nested virtuals work', function() {
         assert.ok(doc);
         assert.equal(doc.nested.test, 'Foo');
         assert.equal(doc.nested.upperCaseTest, 'FOO');
+        assert.equal(doc.nested.objectTest.test, 'Bar');
+        assert.equal(doc.nested.virtualObjectTest.test, 'Bar');
+      });
+    });
+  });
+});
+
+describe('Nested object virtuals work (gh-43)', function() {
+  before(function() {
+    createRemovableDocs();
+  });
+  supportedOpsKeys.forEach(key => {
+    it(`with ${key}`, function() {
+      return co(function*() {
+        const docId = getDocIdBySupportedOp(key);
+        const doc = yield supportedOps[key](baseModel, docId);
+        assert.ok(doc);
+        assert.equal(doc.nested.objectTest.test, 'Bar');
+        assert.equal(doc.nested.virtualObjectTest.test, 'Bar');
       });
     });
   });


### PR DESCRIPTION
I noticed that nested virtuals are supported, but do not work if they are an object:

```javascript
const schema = new mongoose.Schema({
  nested: {
    test: {
      a: String
    }
  }
}, { id: false });

schema.virtual('nested.test2').get(function() {
  return this.nested.test;
});
```

Does not work:
```javascript
.lean({virtuals: ['nested.test2']});
```

I've fixed it, added a test, and verified all existing tests pass.