### PR TITLE
fix .length invalid property access on null

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ function applyVirtualsToChildren(doc, schema, res, virtuals, parent) {
       }
     }
 
-    if (virtualsForChild.length > 0) {
+    if (virtualsForChild && virtualsForChild.length > 0) {
       attachVirtuals.call(doc, _schema, _doc, virtualsForChild, res);
       attachedVirtuals = true;
     }


### PR DESCRIPTION
Welcome123."TypeError: Cannot read property 'length' of null
    at applyVirtualsToChildren (/Users/milian/extendedbrain/planfredapp2020/server/node_modules/mongoose-lean-virtuals/index.js:126:27)
    at model.Query.attachVirtuals (/Users/milian/extendedbrain/planfredapp2020/server/node_modules/mongoose-lean-virtuals/index.js:79:3)
    at model.Query.<anonymous> (/Users/milian/extendedbrain/planfredapp2020/server/node_modules/mongoose-lean-virtuals/index.js:52:22)
    at /Users/milian/extendedbrain/planfredapp2020/server/node_modules/mongoose-lean-virtuals/index.js:13:12
    at /Users/milian/extendedbrain/planfredapp2020/server/node_modules/mongoose/lib/query.js:4429:15